### PR TITLE
chore: add automated Go dependency updates

### DIFF
--- a/.github/workflows/go_dependencies.yml
+++ b/.github/workflows/go_dependencies.yml
@@ -1,0 +1,69 @@
+name: Update Go dependencies
+on:
+  schedule:
+    - cron: "0 0 * * 1" # Every Monday at 00:00 UTC
+  workflow_dispatch:
+
+jobs:
+  update-deps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+          cache: true
+
+      - name: Cache Go modules
+        uses: actions/cache@v5
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Update dependencies
+        id: update
+        run: |
+          set -eo pipefail
+          go env GOPROXY
+          go get -u ./... 2>&1 | tee /tmp/go-get-output.txt
+          go mod tidy
+
+          # Build a summary of what changed in go.mod
+          CHANGES=$(git diff go.mod | grep '^[+-]' | grep -v '^[+-][+-][+-]' | grep -v '^[+-]module' | grep -v '^[+-]go ' || true)
+          echo "CHANGES<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          branch: chore/update-go-deps
+          commit-message: "chore: go get -u && go mod tidy"
+          title: "chore: update Go dependencies"
+          body: |
+            ## Dependency Updates
+
+            Automated update via `go get -u ./... && go mod tidy`.
+
+            ### Changes to go.mod
+            ```diff
+            ${{ steps.update.outputs.CHANGES }}
+            ```
+          labels: dependencies, go


### PR DESCRIPTION
Introduces a weekly GitHub Actions workflow to keep Go modules up to date.

- Runs every Monday at 00:00 UTC.
- Automatically generates a pull request with dependency changes.
- Uses a GitHub App token for secure PR creation and commits.

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Go as Go Modules
    participant PR as Pull Request

    GH->>Go: go get -u ./...
    GH->>Go: go mod tidy
    GH->>PR: Create/Update chore/update-go-deps
```